### PR TITLE
update NuGet config to point at master

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,13 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/" />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetmaster/" />
     <add key="NuGet.org" value="https://nuget.org/api/v2/" />
   </packageSources>
-  <packageSourceCredentials>
-    <AspNetVNext>
-      <add key="Username" value="aspnetreadonly" />
-      <add key="ClearTextPassword" value="4d8a2d9c-7b80-4162-9978-47e918c9658c" />
-    </AspNetVNext>
-  </packageSourceCredentials>
 </configuration>


### PR DESCRIPTION
When following the instructions on the vNext site for OS X and using yo, 'k kestrel' doesn't work.  It's installing the wrong version of the NuGet packages during kpm restore.
